### PR TITLE
External modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ubuntu or Debian
 * `prosody_allow_registration: False`
 * `prosody_modules: [ private, vcard, ping, register ]`
 * `prosody_external_modules: []`
+* `prosody_external_modules_path: /usr/share/prosody-external-modules`
 * `prosody_s2s_secure_domains: [ jabber.org, jabber.ccc.de, jabber.de ]`
 * `prosody_s2s_secure_auth: False`
 * `prosody_authentication: internal_hashed`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ prosody_modules:
   - vcard
   - ping
   - register
+prosody_external_modules_path: /usr/share/prosody-external-modules
 prosody_external_modules: []
 prosody_s2s_secure_domains:
   - jabber.org

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
     repo: https://hg.prosody.im/prosody-modules/
     revision: default
     update: true
-    dest: /usr/share/prosody-external-modules
+    dest: "{{ prosody_external_modules_path }}"
   tags:
     - skip_ansible_lint
 

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -58,6 +58,11 @@ modules_enabled = {
 	"{{ module }}";
 {% endfor %}
 
+	-- External modules
+{% for module in prosody_external_modules %}
+	"{{ module }}";
+{% endfor %}
+
 }
 
 -- These modules are auto-loaded, but should you want

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -38,7 +38,7 @@ use_libevent = true
 
 {% if prosody_external_modules |length > 0 %}
 -- These paths are searched in the order specified, and before the default path
-plugin_paths = { "/usr/share/prosody-external-modules" }
+plugin_paths = { "{{ prosody_external_modules_path }}" }
 {% endif %}
 
 -- This is the list of modules Prosody will load on startup.


### PR DESCRIPTION
This PR allows one to choose where the external modules repository will be cloned. It also fix what I assume to be a bug in the previous definition of `prosody_external_modules` as they were not included in the modules_enabled list of prosody.conf.lua.