### PR TITLE
Port to OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Ubuntu or Debian
 * `prosody_configuration_blocks: []`
 * `prosody_key: /etc/prosody/certs/localhost.key`
 * `prosody_cert: /etc/prosody/certs/localhost.crt`
+* `prosody_libevent: true`
 
 ### Optional Role Variables (with sample values)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,4 @@ prosody_hosts:
   - domain: localhost
 prosody_key: /etc/prosody/certs/localhost.key
 prosody_cert: /etc/prosody/certs/localhost.crt
+prosody_libevent: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
       versions:
         - jessie
         - stretch
+    - name: OpenBSD
+      versions:
+        - 6.5
   galaxy_tags:
     - networking
     - chat

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,0 +1,13 @@
+---
+- name: Debian - Add Prosody repository key
+  apt_key:
+    url: https://prosody.im/files/prosody-debian-packages.key
+    state: present
+
+- name: Debian - Add Prosody repository
+  apt_repository:
+    repo: "deb http://packages.prosody.im/debian {{ ansible_distribution_release }} main"
+
+- name: Debian - Install Prosody and dependencies
+  apt:
+    name: ['mercurial', 'lua-event', 'lua-zlib', '{{ prosody_package }}']

--- a/tasks/install-OpenBSD.yml
+++ b/tasks/install-OpenBSD.yml
@@ -1,0 +1,5 @@
+---
+- name: OpenBSD - Install Prosody and dependencies
+  package:
+    name: ['{{ prosody_package }}', mercurial]
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,15 @@
 ---
 # tasks file for ansible-role-prosody
-- name: Add Prosody repository key
-  apt_key:
-    url: https://prosody.im/files/prosody-debian-packages.key
-    state: present
 
-- name: Add Prosody repository
-  apt_repository:
-    repo: "deb http://packages.prosody.im/debian {{ ansible_distribution_release }} main"
-
-- name: Install Prosody and dependencies
-  apt:
-    name: ['mercurial', 'lua-event', 'lua-zlib', '{{ prosody_package }}']
+- name: Include OS specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
+- name: Include OS specific tasks
+  include: "install-{{ ansible_os_family }}.yml"
 
 - name: Configure Prosody
   template:
     src: prosody.cfg.lua
     dest: /etc/prosody/prosody.cfg.lua
-    group: root
     owner: root
     mode: 0755
   notify: restart prosody

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,20 @@
   tags:
     - skip_ansible_lint
 
+- name: Create prosody log directory
+  file:
+    state: directory
+    path: /var/log/prosody
+    owner: "{{ prosody_user }}"
+    mode: 0755
+
+- name: Create prosody pid directory
+  file:
+    state: directory
+    path: /var/run/prosody
+    owner: "{{ prosody_user }}"
+    mode: 0755
+
 - name: Start and enable prosody on boot
   service:
     name: prosody

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Include OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 - name: Include OS specific tasks
-  include: "install-{{ ansible_os_family }}.yml"
+  include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Configure Prosody
   template:

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -121,7 +121,7 @@ s2s_secure_auth = {{ bool(prosody_s2s_secure_auth) }}
 s2s_secure_domains = { {{ quoted_list(prosody_s2s_secure_domains) }} }
 
 -- Required for init scripts and prosodyctl
-pidfile = "/var/run/prosody/prosody.pid"
+pidfile = "/var/prosody/prosody.pid"
 
 -- Select the authentication backend to use. The 'internal' providers
 -- use Prosody's configured data storage to store the authentication data.

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -34,7 +34,7 @@ admins = { {{ quoted_list(prosody_admins) }} }
 
 -- Enable use of libevent for better performance under high load
 -- For more information see: http://prosody.im/doc/libevent
-use_libevent = true
+use_libevent = {{ prosody_libevent | bool }}
 
 {% if prosody_external_modules |length > 0 %}
 -- These paths are searched in the order specified, and before the default path

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -36,6 +36,9 @@ admins = { {{ quoted_list(prosody_admins) }} }
 -- For more information see: http://prosody.im/doc/libevent
 use_libevent = {{ prosody_libevent | bool }}
 
+prosody_user = "{{ prosody_user }}"
+prosody_group = "{{ prosody_group }}"
+
 {% if prosody_external_modules |length > 0 %}
 -- These paths are searched in the order specified, and before the default path
 plugin_paths = { "{{ prosody_external_modules_path }}" }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+prosody_user: prosody
+prosody_group: prosody

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,0 +1,6 @@
+---
+prosody_setup_ufw: false
+prosody_user: _prosody
+prosody_group: _prosody
+prosody_libevent: false
+prosody_external_modules_path: /usr/local/lib/prosody/external_modules


### PR DESCRIPTION
This PR breaks the `tasks/main.yml` ans `default/main.yml` into OS-specific parts like `tasks/install-Debian.yml` and `vars/Debian.yml`. It allows to easily port this role to other operating systems, such as OpenBSD.

I introduced the variable `prosody_libevent` as prosody simply doesn't start when it is true on OpenBSD.

PR #6 is needed.