### PR TITLE
Enhance config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ubuntu or Debian
 * `prosody_dhparam_length: 2048`
 * `prosody_hosts: [ {domain: example.com} ]`
 * `prosody_setup_ufw: True`
+* `prosody_components: []`
 
 ### Optional Role Variables (with sample values)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Ubuntu or Debian
 * `prosody_setup_ufw: True`
 * `prosody_components: []`
 * `prosody_configuration_blocks: []`
+* `prosody_key: /etc/prosody/certs/localhost.key`
+* `prosody_cert: /etc/prosody/certs/localhost.crt`
 
 ### Optional Role Variables (with sample values)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ None.
     prosody_ssl_ciphers: "ECDH:DH:!CAMELLIA128:!AES128:!SHA1:!3DES:!MD5:!RC4:!aNULL:!NULL:!EXPORT:!LOW:!MEDIUM"
     prosody_ssl_protocol: tlsv1_2+ # tlsv1_2+ supported since Prosody 0.10
     prosody_dhparam_length: 4096
+    prosody_components:
+      - domain: rooms.example.org
+        type: muc
+        conf: |
+          name = "The example.org chatrooms server"
+          modules_enabled = { "muc_mam", "vcard_muc" }
+          ssl = {
+              key = "/etc/prosody/certs/rooms.example.org.key";
+              certificate = "/etc/prosody/certs/rooms.example.org.crt";
+          }
+    prosody_modules:
+      - motd
+    prosody_configuration_blocks:
+      - comment: motd
+        conf: |
+          motd_text = "Welcome on example.org !"
 
   roles:
    - elnappo.prosody

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Ubuntu or Debian
 * `prosody_hosts: [ {domain: example.com} ]`
 * `prosody_setup_ufw: True`
 * `prosody_components: []`
+* `prosody_configuration_blocks: []`
 
 ### Optional Role Variables (with sample values)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,5 @@ prosody_authentication: internal_hashed
 prosody_dhparam_length: 2048
 prosody_hosts:
   - domain: localhost
+prosody_key: /etc/prosody/certs/localhost.key
+prosody_cert: /etc/prosody/certs/localhost.crt

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -144,6 +144,13 @@ log = {
 	"*syslog";
 }
 
+{% if prosody_configuration_blocks is defined %}
+{% for config_block in prosody_configuration_blocks %}
+{{ config_block.comment | comment(decoration="--") }}
+{{ config_block.conf }}
+{% endfor %}
+{% endif %}
+
 ----------- Virtual hosts -----------
 -- You need to add a VirtualHost entry for each domain you wish Prosody to serve.
 -- Settings under each VirtualHost entry apply *only* to that host.

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -177,3 +177,12 @@ VirtualHost "{{ host.domain }}"
 --
 --Component "gateway.example.com"
 --	component_secret = "password"
+
+{% if prosody_components is defined %}
+{% for component in prosody_components %}
+Component "{{ component.domain }}" "{{ component.type }}"
+{% if component.conf is defined %}
+    {{ component.conf }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/templates/prosody.cfg.lua
+++ b/templates/prosody.cfg.lua
@@ -76,8 +76,8 @@ allow_registration = {{ bool(prosody_allow_registration) }}
 -- These are the SSL/TLS-related settings. If you don't want
 -- to use SSL/TLS, you may comment or remove this
 ssl = {
-	key = "/etc/prosody/certs/localhost.key";
-	certificate = "/etc/prosody/certs/localhost.crt";
+	key = "{{ prosody_key }}";
+	certificate = "{{ prosody_cert }}";
 	dhparam = "/etc/prosody/certs/dh-{{ prosody_dhparam_length }}.pem";
 {% if prosody_ssl_protocol is defined %}
 	protocol = "{{ prosody_ssl_protocol }}";


### PR DESCRIPTION
This PR includes three ameliorations to the current template:

- the ability to define server components ;
- the ability to define arbitrary configuration blocks ;
- the ability to override the default ssl configuration.

For example:

```
prosody_cert: /etc/prosody/certs/foutredi.eu.crt
prosody_key: /etc/prosody/certs/foutredi.eu.key
prosody_configuration_blocks:
  - comment: groups
    conf: |
      groups_file = "/etc/prosody/sharedgroups"
prosody_components:
  - domain: rooms.foutredi.eu
    type: muc
    conf: |
      name = "The foutredi.eu chatrooms server"
      modules_enabled = { "muc_mam", "vcard_muc" }
      ssl = {
          key = "/etc/prosody/certs/rooms.foutredi.eu.key";
          certificate = "/etc/prosody/certs/rooms.foutredi.eu.crt";
      }
```

This PR is standalone but will conflict with #7.